### PR TITLE
src, README: Add support for the "contains" protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,12 @@ import procmaps
 # also: from_path, from_str
 maps = procmaps.from_pid(9001)
 for map_ in maps:
-    print(f"{map_.begin_address}: {map_.pathname}")
+    # `in` can be used to check address inclusion
+    if 0xfeedface in map_:
+        print("this map contains some address!")
+
     # see dict(map_) for all attributes
+    print(f"{map_.begin_address}: {map_.pathname}")
 ```
 
 ## Development

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use libc::pid_t;
+use pyo3::class::PySequenceProtocol;
 use pyo3::exceptions::{Exception, IOError};
 use pyo3::prelude::*;
 use pyo3::{create_exception, wrap_pyfunction};
@@ -92,6 +93,13 @@ impl Map {
             rsprocmaps::Pathname::Path(p) => Ok(Some(p.into())),
             rsprocmaps::Pathname::Mmap => Ok(None),
         }
+    }
+}
+
+#[pyproto]
+impl PySequenceProtocol for Map {
+    fn __contains__(&self, addr: u64) -> PyResult<bool> {
+        Ok(addr >= self.inner.address_range.begin && addr < self.inner.address_range.end)
     }
 }
 


### PR DESCRIPTION
This enables the following:

```python3
import procmaps
import os

map_ = procmaps.from_pid(os.getpid())[0]
if 0xCAFECAFE in map_:
    do_something_special(map_)
```