### PR TITLE
Cargo: enable abi3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 libc = "0.2"
-pyo3 = { version = "0.17", features = ["extension-module"] }
+pyo3 = { version = "0.17", features = ["extension-module", "abi3", "abi3-py37"] }
 rsprocmaps = "0.3"


### PR DESCRIPTION
This should cut down on the number of wheel builds necessary.